### PR TITLE
adds init_app method to HealthCheck and EnvironmentDump classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ app = Flask(__name__)
 health = HealthCheck(app, "/healthcheck")
 envdump = EnvironmentDump(app, "/environment")
 
+# or use init_app with flask app factory
+health = HealthCheck()
+envdump = EnvironmentDump()
+
+health.init_app(app, "/healthcheck")
+envdump.init_app(app, "/environment")
+
 # add your own check function to the healthcheck
 def redis_available():
     client = _redis_client()
@@ -120,7 +127,7 @@ In Runscope's infrastructure, the /healthcheck endpoint is hit surprisingly
 often. haproxy runs on every server, and each haproxy hits every healthcheck
 twice a minute. (So if we have 30 servers in our infrastructure, that's 60
 healthchecks per minute to every Flask service.) Plus, monit hits every
-healthcheck 6 times a minute. 
+healthcheck 6 times a minute.
 
 To avoid putting too much strain on backend services, health check results can
 be cached in process memory. By default, health checks that succeed are cached

--- a/healthcheck/__init__.py
+++ b/healthcheck/__init__.py
@@ -67,6 +67,12 @@ class HealthCheck(object):
         if self.app and self.path:
             app.add_url_rule(self.path, view_func=self.check, **options)
 
+    def init_app(self, app=None, path=None, **kwargs):
+        _healthcheck = HealthCheck(app, path, **kwargs)
+        app.extensions = getattr(app, 'extensions', {})
+        app.extensions['healthcheck'] = _healthcheck
+        return _healthcheck
+
     def add_check(self, func):
         self.checkers.append(func)
 
@@ -142,6 +148,12 @@ class EnvironmentDump(object):
 
         if self.app and self.path:
             app.add_url_rule(self.path, view_func=self.dump_environment)
+
+    def init_app(self, app=None, path=None, **kwargs):
+        _environmentdump = EnvironmentDump(app, path, **kwargs)
+        app.extensions = getattr(app, 'extensions', {})
+        app.extensions['environmentdump'] = _environmentdump
+        return _environmentdump
 
     def add_section(self, name, func):
         if name in self.functions:


### PR DESCRIPTION
Adds support for Flask application factory. No public tests so I could only test with available methods.