### PR TITLE
Make logging on failure optional

### DIFF
--- a/healthcheck/__init__.py
+++ b/healthcheck/__init__.py
@@ -49,6 +49,7 @@ class HealthCheck(object):
                  success_ttl=27, failed_status=500, failed_headers=None,
                  failed_handler=json_failed_handler, failed_ttl=9,
                  exception_handler=basic_exception_handler, checkers=None,
+                 log_on_failure=True,
                  **options):
         self.cache = dict()
 
@@ -63,6 +64,8 @@ class HealthCheck(object):
         self.failed_ttl = float(failed_ttl or 0)
 
         self.exception_handler = exception_handler
+
+        self.log_on_failure = log_on_failure
 
         self.options = options
         self.checkers = checkers or []
@@ -113,7 +116,8 @@ class HealthCheck(object):
 
         if not passed:
             msg = 'Health check "{}" failed with output "{}"'.format(checker.__name__, output)
-            current_app.logger.error(msg)
+            if self.log_on_failure:
+                current_app.logger.error(msg)
 
         timestamp = time.time()
         if passed:


### PR DESCRIPTION
Currently logging with an error on a failure is mandatory. 

I'm using this in a kubernetes context, with sentry being the log destination for all ERROR level messages. As a result this gets noisy with failures that I don't really care about. (I don't care about them because I need the healthcheck to fail regularly - on every roll out of a new version. This is a kubernetes qwerk that I'm happy to provide more details on if you care)

With this patch, logging of the failed case becomes optional.