### PR TITLE
#38 Change default failure status code to 200

### DIFF
--- a/healthcheck/__init__.py
+++ b/healthcheck/__init__.py
@@ -47,7 +47,7 @@ def check_reduce(passed, result):
 class HealthCheck(object):
     def __init__(self, app=None, path=None, success_status=200,
                  success_headers=None, success_handler=json_success_handler,
-                 success_ttl=27, failed_status=500, failed_headers=None,
+                 success_ttl=27, failed_status=200, failed_headers=None,
                  failed_handler=json_failed_handler, failed_ttl=9,
                  exception_handler=basic_exception_handler, checkers=None,
                  log_on_failure=True,

--- a/tests/test_unit/test_healthcheck.py
+++ b/tests/test_unit/test_healthcheck.py
@@ -20,13 +20,22 @@ class BasicHealthCheckTest(unittest.TestCase):
         response = self.client.get(self.path)
         self.assertEqual(200, response.status_code)
 
-    def test_failing_check(self):
+    def test_failing_check_uses_default_status_code(self):
         def fail_check():
             return False, "FAIL"
 
         self.hc.add_check(fail_check)
         response = self.client.get(self.path)
         self.assertEqual(200, response.status_code)
+
+    def test_failing_check_uses_given_status_code(self):
+        def fail_check():
+            return False, "FAIL"
+
+        self.hc.failed_status = 500
+        self.hc.add_check(fail_check)
+        response = self.client.get(self.path)
+        self.assertEqual(500, response.status_code)
 
 
 class BasicEnvironmentDumpTest(unittest.TestCase):

--- a/tests/test_unit/test_healthcheck.py
+++ b/tests/test_unit/test_healthcheck.py
@@ -26,7 +26,7 @@ class BasicHealthCheckTest(unittest.TestCase):
 
         self.hc.add_check(fail_check)
         response = self.client.get(self.path)
-        self.assertEqual(500, response.status_code)
+        self.assertEqual(200, response.status_code)
 
 
 class BasicEnvironmentDumpTest(unittest.TestCase):


### PR DESCRIPTION
Fix for #38

These changes return a 200 status code by default when a healthcheck fails.

WHY:
The 500 status code should be reserved for cases when "the server encountered an unexpected condition that prevented it from fulfilling the request" ([citation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500)). While a failed check is not good, it does not prevent the API from fulfilling the request. A 200 status code would be more appropriate, I think. 