### PR TITLE
return UID if no pwd entry for UID

### DIFF
--- a/healthcheck/__init__.py
+++ b/healthcheck/__init__.py
@@ -196,7 +196,10 @@ class EnvironmentDump(object):
         # Fix for 'Inappopropirate ioctl for device' on posix systems.
         if os.name == "posix":
             import pwd
-            username = pwd.getpwuid(os.geteuid()).pw_name
+            try:
+                username = pwd.getpwuid(os.geteuid()).pw_name
+            except KeyError:
+                username = os.geteuid()
         else:
             username = os.environ.get('USER', os.environ.get('USERNAME', 'UNKNOWN'))
             if username == 'UNKNOWN' and hasattr(os, 'getlogin'):


### PR DESCRIPTION
## Issue
If using this library in a container that has a user UID that does not have a entry in the `passwd` database this will throw a `KeyError`

```
KeyError: 'getpwuid(): uid not found: XXXXX'
```

## Potential Fix
Let's handle this `KeyError` and just return the `UID` running the process instead.

 